### PR TITLE
Updates db.js To Correct Foreign Key Relationships

### DIFF
--- a/server/config/db.js
+++ b/server/config/db.js
@@ -35,19 +35,21 @@ var Tags = db.define('Tags', {
 
 var SnippetTags = db.define('SnippetTags');
 
-Snippet.sync()
-.then(() => CodeSample.sync())
-.then(() => Topic.sync())
-.then(() => Language.sync())
-.then(() => Tags.sync())
-.then(() => Snippet.belongsTo(Topic, {foreignkey: 'TopicId'}))
-.then(() => Topic.hasMany(Snippet, {foreignkey: 'TopicId'}))
+Snippet.sync({force: true})
 .then(() => Snippet.hasMany(CodeSample, {foreignkey: 'SnippetId'}))
 .then(() => CodeSample.belongsTo(Snippet, {foreignkey: 'SnippetId'}))
+.then(() => CodeSample.sync({force: true}))
+.then(() => Snippet.belongsTo(Topic, {foreignkey: { name: 'TopicId'}}))
+.then(() => Topic.hasMany(Snippet, {foreignkey: { name: 'TopicId'}}))
+.then(() => Topic.sync({force: true}))
 .then(() => Snippet.belongsTo(Language, {foreignkey: 'LanguageId'}))
 .then(() => Language.hasMany(Snippet, {foreignkey: 'LanguageId'}))
+.then(() => Language.sync({force: true}))
+.then(() => Snippet.sync({force: true}))
+.then(() => Tags.sync({force: true}))
 .then(() => Tags.belongsToMany(Snippet, {through: SnippetTags, foreignkey: 'TagsId'}))
-.then(() => Snippet.belongsToMany(Tags, {through: SnippetTags, foreignkey: 'SnippetId'}));
+.then(() => Snippet.belongsToMany(Tags, {through: SnippetTags, foreignkey: 'SnippetId'}))
+.then(() => SnippetTags.sync({force: true}));
 
 module.exports = {
   Snippet: Snippet,


### PR DESCRIPTION
In order to properly add foreign key columns in our tables, we needed
to:

* Call the Table.sync() operation after any relations are defined
* Call the 'master' Table.sync() again after relations are defined