### PR TITLE
Updates Snippets Factory with getSnippetById

### DIFF
--- a/client/js/controllers/ViewSnippetController.js
+++ b/client/js/controllers/ViewSnippetController.js
@@ -1,4 +1,9 @@
 angular.module('stackets.view', [])
   .controller('ViewSnippetController', function ($scope, Snippets, $stateParams) {
     console.log('Viewing Snippet No. ', $stateParams.id);
+    $scope.snippet = {};
+    Snippets.getSnippetById($stateParams.id).then(function (snippet) {
+      $scope.snippet = snippet;
+      //console.log('Metadata retrieved from Snippets service: ', JSON.stringify(topics));
+    });
   });

--- a/client/js/services/services.js
+++ b/client/js/services/services.js
@@ -53,12 +53,23 @@ angular.module('stackets.services', [])
       });
     };
 
+    var getSnippetById = function (id) {
+      return $http({
+        method: 'GET',
+        url: '/api/snippets/' + id
+      }).then(function (resp) {
+        data = resp.data;
+        return data;
+      });
+    };
+
     return {
       addSnippet: addSnippet,
       getAllSnippets: getAllSnippets,
       getAllTopics: getAllTopics,
       getAllTags: getAllTags,
       getAllLanguages: getAllLanguages,
+      getSnippetById: getSnippetById,
       data: data,
       topics: topics
     };

--- a/client/partials/view-snippet.html
+++ b/client/partials/view-snippet.html
@@ -1,0 +1,1 @@
+  <h3>{{ snippet.title }}</h3>


### PR DESCRIPTION
Adds function getSnippetById to the services.js file.

Adds a call to this function in the ViewSnippetController.

Now, when you click on a snippet title link in the Recent Snippets
view or from the Search Results, you can see the snippet title in
the View Snippet partial. The rest of the view snippet page UI is
still pending.