### PR TITLE
Include Languages, add "example" column to Snippets

### DIFF
--- a/server/config/db.js
+++ b/server/config/db.js
@@ -4,6 +4,7 @@ var db = new Sequelize('stackets', process.env.POSTGRES_USER, '', {dialect: 'pos
 var Snippet = db.define('Snippet', {
   title: Sequelize.STRING,
   snippet: Sequelize.TEXT,
+  example: Sequelize.TEXT,
   shortDescription: Sequelize.STRING,
   explanation: Sequelize.TEXT
 });

--- a/server/config/db.js
+++ b/server/config/db.js
@@ -4,7 +4,6 @@ var db = new Sequelize('stackets', process.env.POSTGRES_USER, '', {dialect: 'pos
 var Snippet = db.define('Snippet', {
   title: Sequelize.STRING,
   snippet: Sequelize.TEXT,
-  example: Sequelize.TEXT,
   shortDescription: Sequelize.STRING,
   explanation: Sequelize.TEXT
 });

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -1,6 +1,7 @@
 var snippetsController = require('../controllers/snippets-controller.js');
 var tagsController = require('../controllers/tags-controller.js');
 var topicController = require('../controllers/topics-controller.js');
+var languageController = require('../controllers/languages-controller.js');
 var snippetTagsController = require('../controllers/snippet-tags-controller.js');
 
 module.exports = function(app, express) {
@@ -10,6 +11,7 @@ module.exports = function(app, express) {
   app.post('/api/snippets', snippetsController.post);
   app.get('/api/tags', tagsController.get);
   app.get('/api/topics', topicController.get);
+  app.get('/api/languages', languageController.get);
   app.get('/api/SnippetTags', snippetTagsController.get);
 
   app.get('/about', function(req, res) {

--- a/server/controllers/languages-controller.js
+++ b/server/controllers/languages-controller.js
@@ -1,0 +1,11 @@
+var db = require('../config/db.js');
+
+module.exports = {
+  get: function(req, res) {
+    db.Language.findAll({})
+      .then(function(data) {
+        // console.log('inside findAll', data);
+        res.status(200).json(data);
+      });
+  }
+};

--- a/server/controllers/snippets-controller.js
+++ b/server/controllers/snippets-controller.js
@@ -2,17 +2,6 @@ var db = require('../config/db.js');
 
 module.exports = {
   get: function(req, res) {
-    // Implement this once you figure out Many-to-One relation
-    // Simply including "model: db.CodeSamples" to the below "findAll" function does not work
-    // db.CodeSample.findAll({ where: { "SnippetId": Number(snipVals.id) } })
-    //   .then(function(codesamples) {
-    //     var samples = codesamples.map(function(sample) {
-    //       return {
-    //         "codeSample": sample.dataValues.codeSample
-    //       };
-    //     });
-    //   });
-
     db.Snippet.findAll({
       include: [
         {model: db.Topic},
@@ -60,6 +49,19 @@ module.exports = {
   },
 
   getById: function(req, res) {
+
+    // Implement this once you figure out Many-to-One relation
+    // Simply including "model: db.CodeSamples" to the below "findAll" function does not work
+    // db.CodeSample.findAll({ where: { "SnippetId": Number(snipVals.id) } })
+    //   .then(function(codesamples) {
+    //     var samples = codesamples.map(function(sample) {
+    //       return {
+    //         "codeSample": sample.dataValues.codeSample
+    //       };
+    //     });
+    //   });
+
+
     db.Snippet.findOne({
       include: [
         {model: db.Topic},

--- a/server/controllers/snippets-controller.js
+++ b/server/controllers/snippets-controller.js
@@ -3,7 +3,7 @@ var db = require('../config/db.js');
 module.exports = {
   get: function(req, res) {
     db.Snippet.findAll({
-      include: [{model: db.Topic}, {model: db.Tag}]
+      include: [{model: db.Topic}, {model: db.Tag}, {model: db.Language}]
     })
       .then(function(snippets) {
         snippets = snippets.map(function(snippet) {
@@ -31,8 +31,9 @@ module.exports = {
             'createdAt': snipVals.createdAt,
             'updatedAt': snipVals.updatedAt,
             'TopicId': snipVals.TopicId,
-            'LanguageId': snipVals.LanguageId,
             'Topic': snipVals.Topic.dataValues.name,
+            'LanguageId': snipVals.LanguageId,
+            'Language': snipVals.Language.dataValues.name,
             'Tags': tags
           };
         });
@@ -44,7 +45,7 @@ module.exports = {
 
   getById: function(req, res) {
     db.Snippet.findOne({
-      include: [{model: db.Topic}, {model: db.Tag}],
+      include: [{model: db.Topic}, {model: db.Tag}, {model: db.Language}],
       where: { id: Number(req.params.id)}
     })
       .then(function(snippet) {
@@ -69,8 +70,9 @@ module.exports = {
           'createdAt': snipVals.createdAt,
           'updatedAt': snipVals.updatedAt,
           'TopicId': snipVals.TopicId,
-          'LanguageId': snipVals.LanguageId,
           'Topic': snipVals.Topic.dataValues.name,
+          'LanguageId': snipVals.LanguageId,
+          'Language': snipVals.Language.dataValues.name,
           'Tags': tags
         });
       });
@@ -78,7 +80,7 @@ module.exports = {
 
   getMostRecent: function(req, res) {
     db.Snippet.findAll({
-      include: [{model: db.Topic}, {model: db.Tag}],
+      include: [{model: db.Topic}, {model: db.Tag}, {model: db.Language}],
       limit: 10,
       order: '"createdAt" DESC'
     })
@@ -105,8 +107,9 @@ module.exports = {
             'createdAt': snipVals.createdAt,
             'updatedAt': snipVals.updatedAt,
             'TopicId': snipVals.TopicId,
-            'LanguageId': snipVals.LanguageId,
             'Topic': snipVals.Topic.dataValues.name,
+            'LanguageId': snipVals.LanguageId,
+            'Language': snipVals.Language.dataValues.name,
             'Tags': tags
           };
         });
@@ -123,6 +126,7 @@ module.exports = {
       shortDescription: req.body.shortDescription,
       explanation: req.body.explanation,
       TopicId: Number(req.body.TopicId),  // topicId comes as a string from front-end form
+      LanguageId: Number(req.body.TopicId),  // languageId comes as a string from front-end form
     };
 
     // tags: { '1': true, '3': true, 9': true }

--- a/server/controllers/snippets-controller.js
+++ b/server/controllers/snippets-controller.js
@@ -2,8 +2,23 @@ var db = require('../config/db.js');
 
 module.exports = {
   get: function(req, res) {
+    // Implement this once you figure out Many-to-One relation
+    // Simply including "model: db.CodeSamples" to the below "findAll" function does not work
+    // db.CodeSample.findAll({ where: { "SnippetId": Number(snipVals.id) } })
+    //   .then(function(codesamples) {
+    //     var samples = codesamples.map(function(sample) {
+    //       return {
+    //         "codeSample": sample.dataValues.codeSample
+    //       };
+    //     });
+    //   });
+
     db.Snippet.findAll({
-      include: [{model: db.Topic}, {model: db.Tag}, {model: db.Language}]
+      include: [
+        {model: db.Topic},
+        {model: db.Tag},
+        {model: db.Language}
+      ]
     })
       .then(function(snippets) {
         snippets = snippets.map(function(snippet) {
@@ -26,6 +41,7 @@ module.exports = {
             id: snipVals.id,
             title: snipVals.title,
             snippet: snipVals.snippet,
+            example: snipVals.example,
             'shortDescription': snipVals.shortDescription,
             explanation: snipVals.explanation,
             'createdAt': snipVals.createdAt,
@@ -45,7 +61,11 @@ module.exports = {
 
   getById: function(req, res) {
     db.Snippet.findOne({
-      include: [{model: db.Topic}, {model: db.Tag}, {model: db.Language}],
+      include: [
+        {model: db.Topic},
+        {model: db.Tag},
+        {model: db.Language}
+      ],
       where: { id: Number(req.params.id)}
     })
       .then(function(snippet) {
@@ -65,6 +85,7 @@ module.exports = {
           id: snipVals.id,
           title: snipVals.title,
           snippet: snipVals.snippet,
+          example: snipVals.example,
           'shortDescription': snipVals.shortDescription,
           explanation: snipVals.explanation,
           'createdAt': snipVals.createdAt,
@@ -80,7 +101,11 @@ module.exports = {
 
   getMostRecent: function(req, res) {
     db.Snippet.findAll({
-      include: [{model: db.Topic}, {model: db.Tag}, {model: db.Language}],
+      include: [
+        {model: db.Topic},
+        {model: db.Tag},
+        {model: db.Language}
+      ],
       limit: 10,
       order: '"createdAt" DESC'
     })
@@ -102,6 +127,7 @@ module.exports = {
             id: snipVals.id,
             title: snipVals.title,
             snippet: snipVals.snippet,
+            example: snipVals.example,
             'shortDescription': snipVals.shortDescription,
             explanation: snipVals.explanation,
             'createdAt': snipVals.createdAt,

--- a/snippetData/seeder.js
+++ b/snippetData/seeder.js
@@ -62,6 +62,7 @@ var seedData = function() {
     Snippet.create({
       title: "Dummy title 1",
       snippet: "Dummy snippet 1",
+      example: "Dummy example 1",
       "shortDescription": "Dummy shortDescription 1",
       explanation: "Dummy explanation 1",
       "TopicId": 1,
@@ -74,6 +75,7 @@ var seedData = function() {
     Snippet.create({
       title: "Dummy title 2",
       snippet: "Dummy snippet 2",
+      example: "Dummy example 2",
       "shortDescription": "Dummy shortDescription 2",
       explanation: "Dummy explanation 2",
       "TopicId": 2,
@@ -88,6 +90,7 @@ var seedData = function() {
     Snippet.create({
       title: "Dummy title 3",
       snippet: "Dummy snippet 3",
+      example: "Dummy example 3",
       "shortDescription": "Dummy shortDescription 3",
       explanation: "Dummy explanation 3",
       "TopicId": 4,
@@ -101,6 +104,7 @@ var seedData = function() {
     Snippet.create({
       title: "Dummy title 4",
       snippet: "Dummy snippet 4",
+      example: "Dummy example 4",
       "shortDescription": "Dummy shortDescription 4",
       explanation: "Dummy explanation 4",
       "TopicId": 3,
@@ -112,6 +116,11 @@ var seedData = function() {
     }))
 
   // Insert code samples
+  // At the moment, we couldn't figure out how to implement this
+  // many-to-one relation with multiple CodeSamples to each snippet
+  // in our snippes-controller.js with the "include" join method
+  // For now, each snippet will have one example directly input into
+  // the snippet entries above
   .then(() =>
     CodeSample.create({
       "codeSample": "Test code sample 1",
@@ -136,6 +145,11 @@ var seedData = function() {
     CodeSample.create({
       "codeSample": "Test code sample 5",
       "SnippetId": 3
+    }))
+  .then(() =>
+    CodeSample.create({
+      "codeSample": "Test code sample 5",
+      "SnippetId": 4
     }));
 };
 

--- a/snippetData/seeder.js
+++ b/snippetData/seeder.js
@@ -61,8 +61,7 @@ var seedData = function() {
   .then(() =>
     Snippet.create({
       title: "Dummy title 1",
-      snippet: "Dummy snippet 1",
-      example: "Dummy example 1",
+      snippet: JSON.stringify("var x = \"hello\";\n\nvar print = function () {\n    console.log(x);\n};"),
       "shortDescription": "Dummy shortDescription 1",
       explanation: "Dummy explanation 1",
       "TopicId": 1,
@@ -74,8 +73,7 @@ var seedData = function() {
   .then(() =>
     Snippet.create({
       title: "Dummy title 2",
-      snippet: "Dummy snippet 2",
-      example: "Dummy example 2",
+      snippet: JSON.stringify("Dummy snippet 2"),
       "shortDescription": "Dummy shortDescription 2",
       explanation: "Dummy explanation 2",
       "TopicId": 2,
@@ -89,8 +87,7 @@ var seedData = function() {
   .then(() =>
     Snippet.create({
       title: "Dummy title 3",
-      snippet: "Dummy snippet 3",
-      example: "Dummy example 3",
+      snippet: JSON.stringify("Dummy snippet 3"),
       "shortDescription": "Dummy shortDescription 3",
       explanation: "Dummy explanation 3",
       "TopicId": 4,
@@ -103,8 +100,7 @@ var seedData = function() {
   .then(() =>
     Snippet.create({
       title: "Dummy title 4",
-      snippet: "Dummy snippet 4",
-      example: "Dummy example 4",
+      snippet: JSON.stringify("Dummy snippet 4"),
       "shortDescription": "Dummy shortDescription 4",
       explanation: "Dummy explanation 4",
       "TopicId": 3,

--- a/snippetData/seeder.js
+++ b/snippetData/seeder.js
@@ -22,14 +22,14 @@ var seedData = function() {
   .then(() => Snippet.sync({force: true}))
   .then(() => SnippetTag.sync({force: true}))
 
-  // Insert default topic
+  // Insert default topics
   .then(() => Topic.create({ name: 'Javascript' }))
   .then(() => Topic.create({ name: 'React' }))
   .then(() => Topic.create({ name: 'Angular' }))
   .then(() => Topic.create({ name: 'Database' }))
   .then(() => Topic.create({ name: 'Server' }))
 
-  // Insert default tag
+  // Insert default tags
   .then(() => Tag.create({ tag: 'ES5' }))
   .then(() => Tag.create({ tag: 'ES6' }))
   .then(() => Tag.create({ tag: 'ORM' }))
@@ -40,14 +40,32 @@ var seedData = function() {
   .then(() => Tag.create({ tag: 'Backbone' }))
   .then(() => Tag.create({ tag: 'Unicorns' }))
 
-  // Insert dummy snippet
+  // Insert default languages
+  .then(() => Language.create({ name: 'css', version: '' }))  //1
+  .then(() => Language.create({ name: 'ejs', version: '' }))
+  .then(() => Language.create({ name: 'html', version: '' }))
+  .then(() => Language.create({ name: 'javascript', version: '' }))
+  .then(() => Language.create({ name: 'json', version: '' })) //5
+  .then(() => Language.create({ name: 'jsx', version: '' }))
+  .then(() => Language.create({ name: 'markdown', version: '' }))
+  .then(() => Language.create({ name: 'pgsql', version: '' }))
+  .then(() => Language.create({ name: 'python', version: '' }))
+  .then(() => Language.create({ name: 'sass', version: '' })) //10
+  .then(() => Language.create({ name: 'scss', version: '' }))
+  .then(() => Language.create({ name: 'sql', version: '' }))
+  .then(() => Language.create({ name: 'text', version: '' }))
+  .then(() => Language.create({ name: 'typescript', version: '' }))
+  .then(() => Language.create({ name: 'xml', version: '' }))  //15
+
+  // Insert dummy snippets
   .then(() =>
     Snippet.create({
       title: "Dummy title 1",
       snippet: "Dummy snippet 1",
       "shortDescription": "Dummy shortDescription 1",
       explanation: "Dummy explanation 1",
-      "TopicId": 1
+      "TopicId": 1,
+      "LanguageId": 4
     }).then(function (snippet) {
       SnippetTag.create({ SnippetId: snippet.id, TagId: 2 });
       SnippetTag.create({ SnippetId: snippet.id, TagId: 5 });
@@ -58,7 +76,8 @@ var seedData = function() {
       snippet: "Dummy snippet 2",
       "shortDescription": "Dummy shortDescription 2",
       explanation: "Dummy explanation 2",
-      "TopicId": 2
+      "TopicId": 2,
+      "LanguageId": 8
     }).then(function (snippet) {
       SnippetTag.create({ SnippetId: snippet.id, TagId: 3 });
       SnippetTag.create({ SnippetId: snippet.id, TagId: 4 });
@@ -71,7 +90,8 @@ var seedData = function() {
       snippet: "Dummy snippet 3",
       "shortDescription": "Dummy shortDescription 3",
       explanation: "Dummy explanation 3",
-      "TopicId": 4
+      "TopicId": 4,
+      "LanguageId": 11
     }).then(function (snippet) {
       SnippetTag.create({ SnippetId: snippet.id, TagId: 1 });
       SnippetTag.create({ SnippetId: snippet.id, TagId: 9 });
@@ -83,7 +103,8 @@ var seedData = function() {
       snippet: "Dummy snippet 4",
       "shortDescription": "Dummy shortDescription 4",
       explanation: "Dummy explanation 4",
-      "TopicId": 3
+      "TopicId": 3,
+      "LanguageId": 14
     }).then(function (snippet) {
       SnippetTag.create({ SnippetId: snippet.id, TagId: 2 });
       SnippetTag.create({ SnippetId: snippet.id, TagId: 6 });


### PR DESCRIPTION
Added a lot of entries into the "Language" table. These languages have been labeled according to the ace editor language naming convention. When creating syntax changer for ace editor, you can simply use the "name" property of each Language object. "GET" route for Language still to be made. 